### PR TITLE
Incorporate fixes into dev branch

### DIFF
--- a/gag.py
+++ b/gag.py
@@ -6,6 +6,7 @@ import argparse
 from src.controller import Controller
 
 def main():
+    version = "v1.1.1"
     parser = argparse.ArgumentParser(
     epilog="""
     Docs at http://genomeannotation.github.io/GAG/
@@ -15,6 +16,7 @@ def main():
     )
     parser.add_argument('-f', '--fasta', required=True)
     parser.add_argument('-g', '--gff', required=True)
+    parser.add_argument('-v', '--version', action='version', version="GAG " + version)
     parser.add_argument('-a', '--anno')
     parser.add_argument('-t', '--trim')
     parser.add_argument('-o', '--out')

--- a/src/cds.py
+++ b/src/cds.py
@@ -30,8 +30,10 @@ class CDS(GenePart):
             first_index = self.indices[0][0]
             return [first_index, first_index+2]
         elif strand == '-':
-            first_index = self.indices[0][1]
-            return [first_index-2, first_index]
+            # Quick fix, applies get_stop_indices for - strand
+            last_index_pair = self.indices[len(self.indices)-1]
+            last_index = last_index_pair[1]
+            return [last_index-2, last_index]
 
     def get_stop_indices(self, strand):
         """Returns coordinates of third-to-last and last base of CDS."""
@@ -40,9 +42,9 @@ class CDS(GenePart):
             last_index = last_index_pair[1]
             return [last_index-2, last_index]
         elif strand == '-':
-            last_index_pair = self.indices[len(self.indices)-1]
-            last_index = last_index_pair[0]
-            return [last_index, last_index+2]
+            # Quick fix, applies get_start_indices for - strand
+            first_index = self.indices[0][0]
+            return [first_index, first_index+2]
 
     def sort_attributes(self):
         """Sorts indices, keeping identifiers and phases with their corresponding index pair.

--- a/src/gff_reader.py
+++ b/src/gff_reader.py
@@ -98,8 +98,9 @@ class GFFReader:
             splitpair = pair.split('=')
             if len(splitpair) != 2:
                 continue
+            # Rename key if we get Dbxref instead of xb_xref
             if splitpair[0] == 'Dbxref':
-		key = "db_xref"
+                key = "db_xref"
             else:
                 key = splitpair[0]
             value = splitpair[1]
@@ -123,6 +124,9 @@ class GFFReader:
         # Add annotations if we found any
         if annotations:
             result["annotations"] = annotations
+        # Delete gene name if it is the same as the ID
+        if 'name' in result and result['identifier'] == result['name']:
+            del result['name']
         return result
 
     def extract_cds_args(self, line):

--- a/src/gff_reader.py
+++ b/src/gff_reader.py
@@ -98,11 +98,7 @@ class GFFReader:
             splitpair = pair.split('=')
             if len(splitpair) != 2:
                 continue
-            # Rename key if we get Dbxref instead of xb_xref
-            if splitpair[0] == 'Dbxref':
-                key = "db_xref"
-            else:
-                key = splitpair[0]
+            key = splitpair[0]
             value = splitpair[1]
             if key == "ID":
                 result['identifier'] = value
@@ -110,7 +106,7 @@ class GFFReader:
                 result['name'] = value
             elif key == "Parent":
                 result['parent_id'] = value
-            elif (key == "db_xref" or
+            elif (key == "Dbxref" or
                     key == "Ontology_term" or
                     key == "product"):
                 if key in annotations.keys():

--- a/src/gff_reader.py
+++ b/src/gff_reader.py
@@ -98,7 +98,10 @@ class GFFReader:
             splitpair = pair.split('=')
             if len(splitpair) != 2:
                 continue
-            key = splitpair[0]
+            if splitpair[0] == 'Dbxref':
+		key = "db_xref"
+            else:
+                key = splitpair[0]
             value = splitpair[1]
             if key == "ID":
                 result['identifier'] = value
@@ -106,7 +109,7 @@ class GFFReader:
                 result['name'] = value
             elif key == "Parent":
                 result['parent_id'] = value
-            elif (key == "Dbxref" or
+            elif (key == "db_xref" or
                     key == "Ontology_term" or
                     key == "product"):
                 if key in annotations.keys():

--- a/src/xrna.py
+++ b/src/xrna.py
@@ -235,7 +235,10 @@ class XRNA:
             # Write the annotations 
             for key in self.annotations.keys():
                 for value in self.annotations[key]:
-                    output += '\t\t\t'+key+'\t'+value+'\n'
+                    if key == 'Dbxref':
+                        output += '\t\t\t'+'db_xref'+'\t'+value+'\n'
+                    else:
+                        output += '\t\t\t'+key+'\t'+value+'\n'
             if not self.annotations_contain_product():
                 output += "\t\t\tproduct\thypothetical protein\n"
             output += "\t\t\tprotein_id\tgnl|ncbi|"+self.identifier+"\n"

--- a/test/cds_tests.py
+++ b/test/cds_tests.py
@@ -31,7 +31,7 @@ class TestCDS(unittest.TestCase):
         self.assertEquals(expected, self.test_cds1.get_start_indices('+'))
 
     def test_get_start_indices_neg_strand(self):
-        expected = [4032, 4034]
+        expected = [7434, 7436]
         self.assertEquals(expected, self.test_cds1.get_start_indices('-'))
 
     def test_get_stop_indices_pos_strand(self):
@@ -39,7 +39,7 @@ class TestCDS(unittest.TestCase):
         self.assertEquals(expected, self.test_cds1.get_stop_indices('+'))
 
     def test_get_stop_indices_neg_strand(self):
-        expected = [6630, 6632]
+        expected = [3734, 3736]
         self.assertEquals(expected, self.test_cds1.get_stop_indices('-'))
 
     def test_extract_sequence_pos_strand(self):

--- a/test/gff_reader_tests.py
+++ b/test/gff_reader_tests.py
@@ -252,21 +252,21 @@ class TestGFFReader(unittest.TestCase):
         inbuff = io.BytesIO(text)
         genes, comments, invalids, ignored = self.reader.read_file(inbuff)
         self.assertEquals(1, len(genes))
-        self.assertEquals({"db_xref": ["PRINTS:PR00075"]}, genes[0].mrnas[0].annotations)
+        self.assertEquals({"Dbxref": ["PRINTS:PR00075"]}, genes[0].mrnas[0].annotations)
 
     def test_read_file_annotated_multi_dbxref(self):
         text = self.get_annotated_gff_multi_dbxref()
         inbuff = io.BytesIO(text)
         genes, comments, invalids, ignored = self.reader.read_file(inbuff)
         self.assertEquals(1, len(genes))
-        self.assertEquals({"db_xref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
+        self.assertEquals({"Dbxref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
 
     def test_read_file_annotated_multi_dbxref_repeated_anno(self):
         text = self.get_annotated_gff_multi_dbxref_repeated_anno()
         inbuff = io.BytesIO(text)
         genes, comments, invalids, ignored = self.reader.read_file(inbuff)
         self.assertEquals(1, len(genes))
-        self.assertEquals({"db_xref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
+        self.assertEquals({"Dbxref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
 
     def test_CDS_knows_its_strand(self):
         text = self.get_annotated_gff()

--- a/test/gff_reader_tests.py
+++ b/test/gff_reader_tests.py
@@ -289,6 +289,17 @@ class TestGFFReader(unittest.TestCase):
         self.assertTrue(genes[0].mrnas[0])
         self.assertEquals('-', genes[0].mrnas[0].strand)
 
+    def test_delete_name_if_name_and_id_are_equivalent(self):
+        attr = "ID=BDOR_007864;Name=BDOR_007864\n"
+        parsed = self.reader.parse_attributes(attr)
+        self.assertEqual('BDOR_007864', parsed['identifier'])
+        self.assertTrue('name' not in parsed)
+        
+    def test_dbxref_converted_to_db_xref_correctly(self):
+        attr = "ID=AGLA000002-RA;Name=AglaTmpM000002-RA;Parent=AGLA000002;Dbxref=PRINTS:PR00075,PFAM:foo;\n"
+        parsed = self.reader.parse_attributes(attr)
+        self.assertEqual(["PRINTS:PR00075", "PFAM:foo"], parsed['annotations']['db_xref'])
+
 
 ##########################
 def suite():

--- a/test/gff_reader_tests.py
+++ b/test/gff_reader_tests.py
@@ -252,21 +252,21 @@ class TestGFFReader(unittest.TestCase):
         inbuff = io.BytesIO(text)
         genes, comments, invalids, ignored = self.reader.read_file(inbuff)
         self.assertEquals(1, len(genes))
-        self.assertEquals({"Dbxref": ["PRINTS:PR00075"]}, genes[0].mrnas[0].annotations)
+        self.assertEquals({"db_xref": ["PRINTS:PR00075"]}, genes[0].mrnas[0].annotations)
 
     def test_read_file_annotated_multi_dbxref(self):
         text = self.get_annotated_gff_multi_dbxref()
         inbuff = io.BytesIO(text)
         genes, comments, invalids, ignored = self.reader.read_file(inbuff)
         self.assertEquals(1, len(genes))
-        self.assertEquals({"Dbxref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
+        self.assertEquals({"db_xref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
 
     def test_read_file_annotated_multi_dbxref_repeated_anno(self):
         text = self.get_annotated_gff_multi_dbxref_repeated_anno()
         inbuff = io.BytesIO(text)
         genes, comments, invalids, ignored = self.reader.read_file(inbuff)
         self.assertEquals(1, len(genes))
-        self.assertEquals({"Dbxref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
+        self.assertEquals({"db_xref": ["PRINTS:PR00075", "PFAM:foo"]}, genes[0].mrnas[0].annotations)
 
     def test_CDS_knows_its_strand(self):
         text = self.get_annotated_gff()

--- a/test/gff_reader_tests.py
+++ b/test/gff_reader_tests.py
@@ -295,12 +295,6 @@ class TestGFFReader(unittest.TestCase):
         self.assertEqual('BDOR_007864', parsed['identifier'])
         self.assertTrue('name' not in parsed)
         
-    def test_dbxref_converted_to_db_xref_correctly(self):
-        attr = "ID=AGLA000002-RA;Name=AglaTmpM000002-RA;Parent=AGLA000002;Dbxref=PRINTS:PR00075,PFAM:foo;\n"
-        parsed = self.reader.parse_attributes(attr)
-        self.assertEqual(["PRINTS:PR00075", "PFAM:foo"], parsed['annotations']['db_xref'])
-
-
 ##########################
 def suite():
     suite = unittest.TestSuite()

--- a/test/xrna_tests.py
+++ b/test/xrna_tests.py
@@ -179,6 +179,22 @@ class TestXRNA(unittest.TestCase):
         expected += "\t\t\tprotein_id\tgnl|ncbi|bdor_foo2\n"
         expected += "\t\t\ttranscript_id\tgnl|ncbi|bdor_foo2_mrna\n"
         self.assertEquals(self.test_mrna1.to_tbl(), expected)
+        
+    def test_to_tbl_replace_Dbxref_with_db_xref(self):
+        self.fake_exon.to_tbl.return_value = "fake_exon_to_tbl...\n"
+        self.fake_cds.to_tbl.return_value = "fake_cds_to_tbl...\n"
+        self.test_mrna1.add_annotation('Dbxref', 'fake_Db')
+        expected = "fake_exon_to_tbl...\n"
+        expected += "\t\t\tproduct\thypothetical protein\n"
+        expected += "\t\t\tprotein_id\tgnl|ncbi|bdor_foo2\n"
+        expected += "\t\t\ttranscript_id\tgnl|ncbi|bdor_foo2_mrna\n"
+        expected += "fake_cds_to_tbl...\n"
+        expected += "\t\t\tdb_xref\tfake_Db\n"
+        expected += "\t\t\tproduct\thypothetical protein\n"
+        expected += "\t\t\tprotein_id\tgnl|ncbi|bdor_foo2\n"
+        expected += "\t\t\ttranscript_id\tgnl|ncbi|bdor_foo2_mrna\n"
+        self.assertEquals(self.test_mrna1.to_tbl(), expected)
+
 
     def test_to_tbl_with_annotations(self):
         self.fake_exon.to_tbl.return_value = "fake_exon_to_tbl...\n"


### PR DESCRIPTION
Fixes for #127, #164, and #166 are included.

Issue #127:
The issue appears to be that the ID= and Name= fields for a gene can't be the same otherwise tbl2asn spits out a SEQ_FEAT.LocusTagProblem error. The gene name should be different in an annotation and not simply the ID/locus_tag replicated. The gene name will generally be a human readable name that is assigned while the locus_tag will be a unique identifier of the gene. To fix this issue, we can delete the 'name' key from the results dictionary in gff_reader.py if the values for ID and Name are the same. ID and Name in a gff file becomes locus_tag and gene respectively in the resulting .tbl file. Fixed in 3b3a2e7 and 69b73e9.

Issue #164:
While reading in a gff3/.gff file, it appears that Dbxref is a standard attribute which makes a reference to an external database. This attribute should be written as db_xref in the resulting .tbl file. My first attempt to fix this was in e8755c1 and 298055f. I discovered that modifying the dictionary key to be db_xref instead of the prior Dbxref creates a resulting .gff file where Dbxref is also converted to db_xref which is incorrect. This was reverted in e8bd510 and 1303ca5. I then removed a test I had created as part of commit 3b3a2e7, in commit 4791914. I then added the proper test and fix in 0926cfa and 73b820e respectively.

Issue #166:
Upon review, protein translation for the - strand was fixed with d80f3fa and reverted with 203ce26 and 98da78e. However, the start and stop codons were not being properly found and I applied a quick fix by using the return value from the opposite functions get_start_indices<->get_stop_indices in cds.py. This was done by copying and pasting the branch of the if statement for the + strand to the branch on the - strand for both functions. More information in commit message c284dc8.

After fixing these issues, I added the ability to run the gag.py script with either the -v or --version flags and added a version variable to gag.py so that users can view the version number for gag. We can update this number when we tag releases as well.